### PR TITLE
Allow non-configurable demos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3336,6 +3336,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -3677,39 +3678,6 @@
       "dev": true,
       "requires": {
         "merge": "^1.2.0"
-      }
-    },
-    "execa": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
-      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
-      "requires": {
-        "cross-spawn": "^6.0.0",
-        "get-stream": "^4.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "get-stream": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
       }
     },
     "exit": {
@@ -4152,8 +4120,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4174,14 +4141,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4196,20 +4161,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4326,8 +4288,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4339,7 +4300,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4354,7 +4314,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4362,14 +4321,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4388,7 +4345,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4469,8 +4425,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4482,7 +4437,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4568,8 +4522,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4605,7 +4558,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4625,7 +4577,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4669,14 +4620,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5541,7 +5490,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-svg": {
       "version": "3.0.0",
@@ -7020,6 +6970,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
@@ -7152,6 +7103,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -7328,7 +7280,8 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "2.0.0",
@@ -9678,7 +9631,8 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -10546,7 +10500,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,90 @@
         "@babel/types": "^7.0.0"
       }
     },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.4.0.tgz",
+      "integrity": "sha512-2K8NohdOT7P6Vyp23QH4w2IleP8yG3UJsbRKwA4YP6H8fErcLkFuuEEqbF2/BYBKSNci/FWJiqm6R3VhM/QHgw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-member-expression-to-functions": "^7.0.0",
+        "@babel/helper-optimise-call-expression": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/helper-replace-supers": "^7.4.0",
+        "@babel/helper-split-export-declaration": "^7.4.0"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+          "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0",
+            "jsesc": "^2.5.1",
+            "lodash": "^4.17.11",
+            "source-map": "^0.5.0",
+            "trim-right": "^1.0.1"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.4.0.tgz",
+          "integrity": "sha512-PVwCVnWWAgnal+kJ+ZSAphzyl58XrFeSKSAJRiqg5QToTsjL+Xu1f9+RJ+d+Q0aPhPfBGaYfkox66k86thxNSg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.0.0",
+            "@babel/helper-optimise-call-expression": "^7.0.0",
+            "@babel/traverse": "^7.4.0",
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+          "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.4.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.2.tgz",
+          "integrity": "sha512-9fJTDipQFvlfSVdD/JBtkiY0br9BtfvW2R8wo6CX/Ej2eMuV0gWPk1M67Mt3eggQvBqYW1FCEk8BN7WvGm/g5g==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.0.tgz",
+          "integrity": "sha512-/DtIHKfyg2bBKnIN+BItaIlEg5pjAnzHOIQe5w+rHAw/rg9g0V7T4rqPX8BJPfW11kt3koyjAnTNwCzb28Y1PA==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@babel/generator": "^7.4.0",
+            "@babel/helper-function-name": "^7.1.0",
+            "@babel/helper-split-export-declaration": "^7.4.0",
+            "@babel/parser": "^7.4.0",
+            "@babel/types": "^7.4.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0",
+            "lodash": "^4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.4.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+          "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "lodash": "^4.17.11",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-define-map": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-define-map/-/helper-define-map-7.1.0.tgz",
@@ -385,6 +469,16 @@
         "@babel/helper-plugin-utils": "^7.0.0",
         "@babel/helper-remap-async-to-generator": "^7.1.0",
         "@babel/plugin-syntax-async-generators": "^7.2.0"
+      }
+    },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.4.0.tgz",
+      "integrity": "sha512-t2ECPNOXsIeK1JxJNKmgbzQtoG27KIlVE61vTqX0DKR9E9sZlVVxWUtEW9D5FlZ8b8j7SBNCHY47GgPKCKlpPg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.4.0",
+        "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
     "@babel/plugin-proposal-json-strings": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",
+    "@babel/plugin-proposal-class-properties": "^7.4.0",
     "@babel/preset-env": "^7.3.4",
     "@oclif/dev-cli": "^1.21.0",
     "@oclif/test": "^1.2.2",

--- a/src/tasks/config.js
+++ b/src/tasks/config.js
@@ -18,17 +18,13 @@ class Config {
       shared: this.shared
     };
   }
-  
+
   getTemplate () {
     this.shared.templatePath = this.config.demosDefaults.template;
   };
 
   setVariants () {
-    if (!this.config.demosDefaults.variants) {
-      throw new Error("The 'demosDefaults.variants' property is required");
-    }
-    
-    this.shared.variants = this.config.demosDefaults.variants;
+    this.shared.variants = this.config.demosDefaults.variants || null;
   }
 
   setDependencies () {

--- a/templates/demo/sandbox/app.js
+++ b/templates/demo/sandbox/app.js
@@ -7,9 +7,10 @@ import './main.scss';
 class App extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = { 
-      ...props.config.demo.data, 
-      sidebarVisible: false
+    this.state = {
+      ...props.config.demo.data,
+      sidebarEnabled: Boolean(this.props.config.shared.variants),
+      sidebarVisible: false,
     }
   }
 
@@ -21,25 +22,33 @@ class App extends React.PureComponent {
   }
 
   toggleSidebar = () => {
-    let toggle = this.state.sidebarVisible ? false : true;
+    let toggle = false;
+    if (this.state.sidebarEnabled) {
+      toggle = this.state.sidebarVisible ? false : true;
+    }
     this.setState({ sidebarVisible: toggle })
   }
 
   render() {
     const demo = this.props.config.demo.data;
-    const variant = this.props.config.shared.variants.find(variant => variant.type === demo.type);
+    const variant = this.state.sidebarEnabled ? this.props.config.shared.variants.find(variant => variant.type === demo.type) : null;
 
     return <>
-      <Sidebar 
-        data={variant} 
-        brand={this.props.config.brand} 
-        state={this.state} 
-        handleChange={this.handleChange}/>
-      <DemoArea 
-        demo={demo} 
-        component={this.props.component} 
-        state={this.state} 
-        toggleHTML={this.toggleHTML} 
+      {this.state.sidebarEnabled ?
+        <Sidebar
+          data={variant}
+          brand={this.props.config.brand}
+          state={this.state}
+          handleChange={this.handleChange} />
+        :
+        ''
+      }
+      <DemoArea
+        demo={demo}
+        component={this.props.component}
+        state={this.state}
+        sidebarEnabled={this.state.sidebarEnabled}
+        toggleHTML={this.toggleHTML}
         toggleSidebar={this.toggleSidebar} />
     </>
   }

--- a/templates/demo/sandbox/demo-area.js
+++ b/templates/demo/sandbox/demo-area.js
@@ -43,7 +43,6 @@ class DemoArea extends React.PureComponent {
 
   render() {
 
-    console.log(this.state.sidebarEnabled);
 
     const sidebarToggleButton = (
       <button

--- a/templates/demo/sandbox/demo-area.js
+++ b/templates/demo/sandbox/demo-area.js
@@ -44,21 +44,26 @@ class DemoArea extends React.PureComponent {
   render() {
 
 
-    const sidebarToggleButton = (
-      <button
-        className="o-buttons o-buttons--mono"
-        onClick={() => this.props.toggleSidebar()}>
-          Customise this demo
-      </button>
-    );
+    let selectFullCodeSnippetButton = '';
+    let sidebarToggleButton = '';
 
-    const selectFullCodeSnippetButton = (
-      <button
-        className="o-buttons o-buttons--mono"
-        onClick={() => alert('technically this would select this beautiful markup')}>
-        Select Full Code Snippet
-      </button>
-    );
+    if (this.state.showHTML) {
+      selectFullCodeSnippetButton = (
+        <button
+          className="o-buttons o-buttons--mono"
+          onClick={() => alert('technically this would select this beautiful markup')}>
+          Select Full Code Snippet
+        </button>
+      );
+    } else if (this.state.sidebarEnabled) {
+      sidebarToggleButton = (
+        <button
+          className="o-buttons o-buttons--mono"
+          onClick={() => this.props.toggleSidebar()}>
+            Customise this demo
+        </button>
+      );
+    }
 
     const componentHtmlToggleButton = (
       <button
@@ -72,14 +77,8 @@ class DemoArea extends React.PureComponent {
     );
 
     return <div className="demo-area" data-o-component="o-syntax-highlight">
-      {
-        this.state.showHTML ?
-        selectFullCodeSnippetButton : (
-          this.state.sidebarEnabled ?
-          sidebarToggleButton :
-          ''
-        )
-      }
+      {selectFullCodeSnippetButton}
+      {sidebarToggleButton}
       {componentHtmlToggleButton}
       <Component
         component={this.props.component}

--- a/templates/demo/sandbox/demo-area.js
+++ b/templates/demo/sandbox/demo-area.js
@@ -18,6 +18,7 @@ class DemoArea extends React.PureComponent {
     super(props);
     this.ref = React.createRef();
     this.state =  {
+      sidebarEnabled: props.sidebarEnabled,
       showHTML: false,
       HTML: null,
       buttonText: 'HTML'
@@ -41,33 +42,51 @@ class DemoArea extends React.PureComponent {
   }
 
   render() {
-    return <div className="demo-area" data-o-component="o-syntax-highlight">
-      {!this.state.showHTML ? 
-        <button 
-          className="o-buttons o-buttons--mono" 
-          onClick={() => this.props.toggleSidebar()}>
-            Customise this demo
-        </button>
-        : 
-        <button
-          className="o-buttons o-buttons--mono"
-          onClick={() => alert('technically this would select this beautiful markup')}>
-          Select Full Code Snippet
-        </button>
-      }
-      <button 
-        className="o-buttons o-buttons--mono" 
+
+    console.log(this.state.sidebarEnabled);
+
+    const sidebarToggleButton = (
+      <button
+        className="o-buttons o-buttons--mono"
+        onClick={() => this.props.toggleSidebar()}>
+          Customise this demo
+      </button>
+    );
+
+    const selectFullCodeSnippetButton = (
+      <button
+        className="o-buttons o-buttons--mono"
+        onClick={() => alert('technically this would select this beautiful markup')}>
+        Select Full Code Snippet
+      </button>
+    );
+
+    const componentHtmlToggleButton = (
+      <button
+        className="o-buttons o-buttons--mono"
         onClick={() => {
           this.props.state.sidebarVisible ? this.props.toggleSidebar() : null;
           this.toggleHTML(this.ref);
         }}>
           {this.state.buttonText}
       </button>
-      <Component 
-        component={this.props.component} 
-        ref={this.ref} 
-        state={this.props.state} 
-        markup={this.state} 
+    );
+
+    return <div className="demo-area" data-o-component="o-syntax-highlight">
+      {
+        this.state.showHTML ?
+        selectFullCodeSnippetButton : (
+          this.state.sidebarEnabled ?
+          sidebarToggleButton :
+          ''
+        )
+      }
+      {componentHtmlToggleButton}
+      <Component
+        component={this.props.component}
+        ref={this.ref}
+        state={this.props.state}
+        markup={this.state}
         demo={this.props.demo} />
     </div>
   }

--- a/test/unit/tasks/config.test.js
+++ b/test/unit/tasks/config.test.js
@@ -27,9 +27,10 @@ describe('Config', () => {
       expect(config.shared.variants).toEqual([])
     });
 
-    test('throws an error if variant rules are not defined', () => {
-      mockData.demosDefaults.variants = null;
-      expect(() => new Config(mockData)).toThrowError("The 'demosDefaults.variants' property is required")
+    test('sets component variants to null if rules are not defined', () => {
+      mockData.demosDefaults.variants = undefined;
+      let config = new Config(mockData);
+      expect(config.shared.variants).toBeNull()
     });
   });
 


### PR DESCRIPTION
This allows demos to be non-configurable. Demos with no `variants`
property in the demo defaults will now be generated correctly, but they
will not include the sidebar. We may want to have non-customisable demos
in the future, and this also aids development as you can get something
up-and-running sooner.

I've moved the buttons in `demo-area.js` to avoid complex nested
ternaries. I have no idea whether this is Reacty, but named variables
makes things easier to keep track of 🤷‍♂️